### PR TITLE
Fix for unhandled click to stop button before screen window sharing permission.

### DIFF
--- a/main.js
+++ b/main.js
@@ -118,6 +118,9 @@ class RecordView {
       m.redraw();
       return;
     }
+    
+    const stopButton = vnode.dom.getElementsByTagName("section")[1].childNodes[0];
+    stopButton.removeAttribute("disabled");
 
     video.srcObject = captureStream;
 
@@ -167,7 +170,7 @@ class RecordView {
 
   view() {
     const actions = [
-      m(Button, { label: 'Stop', icon: 'primitive-square', onclick: () => this.app.stopRecording() })
+      m(Button, { label: 'Stop', disabled: true, icon: 'primitive-square', onclick: () => this.app.stopRecording() })
     ];
 
     return [


### PR DESCRIPTION
In Firefox, you can click the stop button while you are giving to the browser screen sharing permissions, so I've created the Stop button disabled and I've enabled after `navigator.mediaDevices.getDisplayMedia` try-catch statement. This prevents next error to be raised:
```
TypeError: Argument 1 of CanvasRenderingContext2D.putImageData is not an object.
```