### PR TITLE
Improve screen recording dimensions

### DIFF
--- a/main.js
+++ b/main.js
@@ -632,7 +632,7 @@ class App {
     }
 
     try {
-      const captureStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
+      const captureStream = await navigator.mediaDevices.getDisplayMedia({ video: { width: 9999, height: 9999 } });
 
       this.state = 'recording';
       this.recording = {


### PR DESCRIPTION
`navigator.mediaDevices.getDisplayMedia` provides less-than-actual video output, especially for HD, 4K, or HiDPI screen. This results in GIFs that look blurry due to downscaling. Adding this constrain results in original display scale, leading to a crisper output.

## Without this PR

![recording (1)](https://user-images.githubusercontent.com/193136/98409048-c498b680-20a4-11eb-98d2-b820b72d1493.gif)

## With this PR

![recording (2)](https://user-images.githubusercontent.com/193136/98409056-c6627a00-20a4-11eb-939e-31a4f044ad8f.gif)

## Userland patch

```js
// ==UserScript==
// @name         Improve gifcap resolution
// @namespace    https://dt.in.th/
// @version      0.1
// @description  Make gifcap capture screen at actual size, resulting in crisper image
// @author       dtinth
// @match        https://gifcap.dev/
// @grant        none
// ==/UserScript==

(function() {
    'use strict';
    navigator.mediaDevices.getDisplayMedia = (o => function(...args) {
        args[0].video = { width: 9999, height: 9999 }
        return o.apply(this, args)
    })(navigator.mediaDevices.getDisplayMedia)
})();
```